### PR TITLE
add config files for unified encoding accross dev platforms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.css text eol=lf


### PR DESCRIPTION
Добавил конфиг редактора кода, чтобы не было ошибок кодировок винда <–> UTF-8

Это критично только для комментариев, но все же. Для сохранности лучше еще поставить в настройках редактора кода UTF-8 на винде. 